### PR TITLE
escape the key within the s3 bucket before constructing the url

### DIFF
--- a/gof3r/get.go
+++ b/gof3r/get.go
@@ -20,7 +20,7 @@ var get Get
 
 func (get *Get) Execute(args []string) (err error) {
 	conf := new(s3gof3r.Config)
-	conf = s3gof3r.DefaultConfig
+	*conf = *s3gof3r.DefaultConfig
 	k, err := getAWSKeys()
 	if err != nil {
 		return

--- a/gof3r/put.go
+++ b/gof3r/put.go
@@ -19,7 +19,7 @@ var put Put
 
 func (put *Put) Execute(args []string) (err error) {
 	conf := new(s3gof3r.Config)
-	conf = s3gof3r.DefaultConfig
+	*conf = *s3gof3r.DefaultConfig
 	k, err := getAWSKeys()
 	if err != nil {
 		return


### PR DESCRIPTION
important for keys with spaces, etc
