### PR TITLE
Add support for HTTP_PROXY and without-ssl flag

### DIFF
--- a/gof3r/get.go
+++ b/gof3r/get.go
@@ -30,6 +30,9 @@ func (get *Get) Execute(args []string) (err error) {
 	if get.Concurrency > 0 {
 		conf.Concurrency = get.Concurrency
 	}
+	if get.WithoutSSL {
+		conf.Scheme = "http"
+	}
 	conf.PartSize = get.PartSize
 	conf.Md5Check = !get.CheckDisable
 	get.Key = url.QueryEscape(get.Key)

--- a/gof3r/main.go
+++ b/gof3r/main.go
@@ -96,6 +96,7 @@ type CommonOpts struct {
 	//Url         string      `short:"u" long:"url" description:"Url of S3 object"` //TODO: bring back url support
 	Key          string `long:"key" short:"k" description:"key of s3 object" required:"true"`
 	Bucket       string `long:"bucket" short:"b" description:"s3 bucket" required:"true"`
+	WithoutSSL   bool   `long:"without-ssl" description:"do not use SSL for endpoint connection"`
 	CheckDisable bool   `long:"md5Check-off" description:"Do not use md5 hash checking to ensure data integrity. By default, the md5 hash of is calculated concurrently during puts, stored at <bucket>.md5/<key>.md5, and verified on gets."`
 	Concurrency  int    `long:"concurrency" short:"c" default:"10" description:"Concurrency of transfers"`
 	PartSize     int64  `long:"partsize" short:"s" description:"initial size of concurrent parts, in bytes" default:"20971520"`

--- a/gof3r/put.go
+++ b/gof3r/put.go
@@ -30,6 +30,9 @@ func (put *Put) Execute(args []string) (err error) {
 	if put.Concurrency > 0 {
 		conf.Concurrency = put.Concurrency
 	}
+	if put.WithoutSSL {
+		conf.Scheme = "http"
+	}
 	conf.PartSize = put.PartSize
 	conf.Md5Check = !put.CheckDisable
 	put.Key = url.QueryEscape(put.Key)

--- a/http_client.go
+++ b/http_client.go
@@ -27,6 +27,7 @@ func (c *deadlineConn) Write(b []byte) (n int, err error) {
 
 func ClientWithTimeout(timeout time.Duration) *http.Client {
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: func(netw, addr string) (net.Conn, error) {
 			c, err := net.DialTimeout(netw, addr, timeout)
 			if err != nil {


### PR DESCRIPTION
Most private object storage solutions support direct and proxy configurations. For clients interacting with object stores in a direct configuration, overriding `endpoint` works. In order to support object stores in a proxy configuration, this commit adds support for the `HTTP_PROXY` environmental variable (along with a `without-ssl` flag for interacting with object stores without HTTPS).

Example usage:

``` bash
$ HTTP_PROXY="http://localhost:8080" ./gof3r put --without-ssl \
--path=/Users/hector/Downloads/ubuntu-14.04-server-amd64.iso \
--bucket=isos --key=ubuntu-14.04-server-amd64.iso
2014/05/11 22:47:09 Duration: 28.509582349s

$ HTTP_PROXY="http://localhost:8080" ./gof3r get --without-ssl \
--path=ubuntu-14.04-server-amd64.iso \
--bucket=isos --key=ubuntu-14.04-server-amd64.iso
2014/05/11 22:48:04 Duration: 16.278402355s

$ md5 ubuntu-14.04-server-amd64.iso ~/Downloads/ubuntu-14.04-server-amd64.iso
MD5 (ubuntu-14.04-server-amd64.iso) = 01545fa976c8367b4f0d59169ac4866c
MD5 (/Users/hector/Downloads/ubuntu-14.04-server-amd64.iso) = 01545fa976c8367b4f0d59169ac4866c
```

(This test was done against a local instance of Riak CS with the S3 API enabled.)
