### PR TITLE
Fix request signature for non-urlsafe object names

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -105,7 +106,8 @@ func (b *Bucket) writeCanonicializedResource(w io.Writer, r *http.Request) {
 		w.Write([]byte("/"))
 		w.Write([]byte(b.Name))
 	}
-	w.Write([]byte(r.URL.Path))
+	u := &url.URL{Path: r.URL.Path}
+	w.Write([]byte(u.String()))
 	b.writeSubResource(w, r)
 }
 


### PR DESCRIPTION
Object names that would be transformed by url percent encoding would fail with the error

```
"The request signature we calculated does not match the signature you provided. Check your key and signing method."
```

In these cases, the canonicalized URI used for signing is different from the URI the signature is sent to.  The initial quoting is done here:

https://github.com/rlmcpherson/s3gof3r/blob/c8635b85d6b6d05ff0a959fd5b71c53305e72c11/putter.go#L81
