### PR TITLE
Fix for home directory not found on Windows

### DIFF
--- a/gof3r/Godeps/Godeps.json
+++ b/gof3r/Godeps/Godeps.json
@@ -6,6 +6,10 @@
 			"ImportPath": "github.com/jessevdk/go-flags",
 			"Comment": "v1-269-g292b1d4",
 			"Rev": "292b1d4972df6bccb10ef105f89c8e2fd509780e"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/go-homedir",
+			"Rev": "7d2d8c8a4e078ce3c58736ab521a40b37a504c52"
 		}
 	]
 }

--- a/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/LICENSE
+++ b/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/README.md
+++ b/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir.go
+++ b/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,83 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if runtime.GOOS == "windows" {
+		return dirWindows()
+	}
+
+	// Unix-like system, so just assume Unix
+	return dirUnix()
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return dir + path[1:], nil
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try the shell
+	var stdout bytes.Buffer
+	cmd := exec.Command("sh", "-c", "eval echo ~$USER")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir_test.go
+++ b/gof3r/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir_test.go
@@ -1,0 +1,77 @@
+package homedir
+
+import (
+	"fmt"
+	"os/user"
+	"testing"
+)
+
+func TestDir(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+			"/foo",
+			"/foo",
+			false,
+		},
+
+		{
+			"~/foo",
+			fmt.Sprintf("%s/foo", u.HomeDir),
+			false,
+		},
+		
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
+
+		{
+			"~foo/foo",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := Expand(tc.Input)
+		if (err != nil) != tc.Err {
+			t.Fatalf("Input: %#v\n\nErr: %s", tc.Input, err)
+		}
+
+		if actual != tc.Output {
+			t.Fatalf("Input: %#v\n\nOutput: %#v", tc.Input, actual)
+		}
+	}
+}

--- a/gof3r/options.go
+++ b/gof3r/options.go
@@ -5,10 +5,9 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/jessevdk/go-flags"
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -64,7 +63,7 @@ func init() {
 }
 
 func iniPath() (path string, exist bool, err error) {
-	hdir, err := homeDir()
+	hdir, err := homedir.Dir()
 	if err != nil {
 		return
 	}
@@ -98,18 +97,6 @@ func writeIni() {
 		fmt.Fprintf(os.Stderr, "ini file written to %s\n", p)
 	}
 	os.Exit(0)
-}
-
-// find unix home directory
-func homeDir() (string, error) {
-	if h := os.Getenv("HOME"); h != "" {
-		return h, nil
-	}
-	h, err := exec.Command("sh", "-c", "eval echo ~$USER").Output()
-	if err == nil && len(h) > 0 {
-		return strings.TrimSpace(string(h)), nil
-	}
-	return "", fmt.Errorf("home directory not found for current user")
 }
 
 // add canned acl to http.Header

--- a/gof3r/options_test.go
+++ b/gof3r/options_test.go
@@ -3,34 +3,9 @@ package main
 import (
 	"log"
 	"net/http"
-	"os"
-	"os/user"
 	"reflect"
 	"testing"
 )
-
-func TestHomeDir(t *testing.T) {
-	hs := os.Getenv("HOME")
-	defer os.Setenv("HOME", hs)
-
-	u, err := user.Current()
-	if err != nil {
-		t.Fatal(err)
-	}
-	thdir := u.HomeDir
-
-	if err := os.Setenv("HOME", ""); err != nil {
-		t.Fatal(err)
-	}
-	hdir, err := homeDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if hdir != thdir {
-		t.Errorf("expected %s\n actual%s\n", thdir, hdir)
-	}
-
-}
 
 func TestACL(t *testing.T) {
 	h2 := http.Header{"X-Amz-Acl": []string{"public-read"}}


### PR DESCRIPTION
After cross-compiling `gof3r` for `windows/amd64` and running the binary
I got the following error,

home directory not found for current user
![screenshot](https://cloud.githubusercontent.com/assets/6806679/5286223/bc280b00-7b22-11e4-86f6-d0b1fd9090da.png)

The fix for this error is to use the third-party package `go-homedir`, which
detects "the user's home directory without the use of cgo, so the library
can be used in cross-compilation environments."
