### PR TITLE
change naked URL to a link from "IAM role"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To try the latest release of the gof3r command-line interface without installing
   $ export AWS_SECRET_ACCESS_KEY=<secret_key>
 ```
 
-gof3r also supports IAM role-based keys from EC2 instance metadata. If available and environment variables are not set, these keys are used are used automatically. (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+gof3r also supports [IAM role](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)-based keys from EC2 instance metadata. If available and environment variables are not set, these keys are used are used automatically.
 
  Examples:
 


### PR DESCRIPTION
This is a minor change; I don't know if there's a reason to prefer having the whole URL appear, but I believe this will preserve the content and look nicer.