### PR TITLE
Getter should not treat HTTP 200 as an error.

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -183,7 +183,7 @@ func (g *getter) getChunk(c *chunk) error {
 		return err
 	}
 	defer checkClose(resp.Body, err)
-	if resp.StatusCode != 206 {
+	if resp.StatusCode != 206 && resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
 	n, err := io.ReadAtLeast(resp.Body, c.b, int(c.size))


### PR DESCRIPTION
Closes #75

I've tested this against an S3 key that cannot be fetched correctly using 0.4.10; it works.