### PR TITLE
Fix small file requests

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -183,7 +183,7 @@ func (g *getter) getChunk(c *chunk) error {
 		return err
 	}
 	defer checkClose(resp.Body, err)
-	if resp.StatusCode != 206 {
+	if resp.StatusCode != 206 && resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
 	n, err := io.ReadAtLeast(resp.Body, c.b, int(c.size))


### PR DESCRIPTION
AWS S3 returns response code 200 instead of 206 for small files. This allows s3gof3r to fetch these small files too without this error output:

>> 2015/11/03 11:37:26 error on attempt 0: retrying chunk: 0, error: 200: ""
>> 2015/11/03 11:37:26 error on attempt 1: retrying chunk: 0, error: 200: ""
>> 2015/11/03 11:37:26 error on attempt 2: retrying chunk: 0, error: 200: ""
>> 2015/11/03 11:37:27 error on attempt 3: retrying chunk: 0, error: 200: ""
>> 2015/11/03 11:37:28 error on attempt 4: retrying chunk: 0, error: 200: ""
>> 2015/11/03 11:37:29 error on attempt 5: retrying chunk: 0, error: 200: ""