### PR TITLE
Only set err if not set

### DIFF
--- a/putter.go
+++ b/putter.go
@@ -187,7 +187,9 @@ func (p *putter) retryPutPart(part *part) {
 		logger.debugPrintf("Error on attempt %d: Retrying part: %d, Error: %s", i, part.PartNumber, err)
 		time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
 	}
-	p.err = err
+	if p.err == nil {
+		p.err = err
+	}
 }
 
 // uploads a part, checking the etag against the calculated value

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -565,6 +565,7 @@ func TestBucketURL(t *testing.T) {
 		{"bucket1", "#path ", DefaultConfig, `https://bucket1.s3.amazonaws.com/%23path%20`},
 		{"bucket.2", "path", DefaultConfig, "https://s3.amazonaws.com/bucket.2/path"},
 		{"bucket.2", "#path", DefaultConfig, `https://s3.amazonaws.com/bucket.2/%23path`},
+		{"bucket.2", "#path?versionId=seQK1YwRAy6Ex25YHb_yJHbo94jSDnpu", DefaultConfig, `https://s3.amazonaws.com/bucket.2/%23path%3FversionId=seQK1YwRAy6Ex25YHb_yJHbo94jSDnpu`}, // versionId-specific handling
 	}
 
 	for _, tt := range urlTests {


### PR DESCRIPTION
Since this variable is re-used across the various workers, it might get set to nil unexpectedly in certain scenarios. Perhaps we should only let the first non-nil in win.