### PR TITLE
Use AWS_SECURITY_TOKEN environment variable

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -80,8 +80,10 @@ func InstanceKeys() (keys Keys, err error) {
 
 // EnvKeys Reads the AWS keys from the environment
 func EnvKeys() (keys Keys, err error) {
-	keys = Keys{AccessKey: os.Getenv("AWS_ACCESS_KEY_ID"),
-		SecretKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+	keys = Keys{
+		AccessKey:     os.Getenv("AWS_ACCESS_KEY_ID"),
+		SecretKey:     os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		SecurityToken: os.Getenv("AWS_SECURITY_TOKEN"),
 	}
 	if keys.AccessKey == "" || keys.SecretKey == "" {
 		err = fmt.Errorf("keys not set in environment: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY")

--- a/auth_test.go
+++ b/auth_test.go
@@ -6,17 +6,6 @@ import (
 	"testing"
 )
 
-var testKeys = Keys{
-	AccessKey: "AKIDEXAMPLE",
-	SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-}
-
-var testTokenKeys = Keys{
-	AccessKey:     "AKIDEXAMPLE",
-	SecretKey:     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-	SecurityToken: "testtoken",
-}
-
 type authT struct {
 	env []string
 }
@@ -36,11 +25,36 @@ func (s *authT) restoreEnv() {
 	}
 }
 
-func TestEnvKeys(t *testing.T) {
+func TestEnvKeysWithoutToken(t *testing.T) {
+	testKeys := Keys{
+		AccessKey: "AKIDEXAMPLE",
+		SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+	}
 	s := authT{}
 	s.saveEnv()
 	os.Setenv("AWS_ACCESS_KEY_ID", testKeys.AccessKey)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", testKeys.SecretKey)
+	keys, err := EnvKeys()
+	if err != nil {
+		t.Error(err)
+	}
+	if keys != testKeys {
+		t.Errorf("Keys do not match. Expected: %v. Actual: %v", testKeys, keys)
+	}
+	s.restoreEnv()
+}
+
+func TestEnvKeyWithToken(t *testing.T) {
+	testKeys := Keys{
+		AccessKey:     "AKIDEXAMPLE",
+		SecretKey:     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		SecurityToken: "testtoken",
+	}
+	s := authT{}
+	s.saveEnv()
+	os.Setenv("AWS_ACCESS_KEY_ID", testKeys.AccessKey)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", testKeys.SecretKey)
+	os.Setenv("AWS_SECURITY_TOKEN", testKeys.SecurityToken)
 	keys, err := EnvKeys()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
`gof3r` should work with environments that have temporary tokens. These
environments set a AWS_SECURITY_TOKEN. Without the token the comannd
will always fail due to authorization errors.

This change optionally pulls in AWS_SECURITY_TOKEN and sets it so
`gof3r` can run as expected.