### PR TITLE
Retry "500 InternalError" after a short delay in retryRequest

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -116,6 +116,13 @@ func (g *getter) retryRequest(method, urlStr string, body io.ReadSeeker) (resp *
 			return
 		}
 		logger.debugPrintln(err)
+
+		// retry internal server errors after a short delay
+		if resp.StatusCode == 500 {
+			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
+			continue
+		}
+
 		if body != nil {
 			if _, err = body.Seek(0, 0); err != nil {
 				return

--- a/getter.go
+++ b/getter.go
@@ -118,7 +118,7 @@ func (g *getter) retryRequest(method, urlStr string, body io.ReadSeeker) (resp *
 		logger.debugPrintln(err)
 
 		// retry internal server errors after a short delay
-		if resp.StatusCode == 500 {
+		if resp != nil && resp.StatusCode == 500 {
 			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
 			continue
 		}

--- a/putter.go
+++ b/putter.go
@@ -385,6 +385,13 @@ func (p *putter) retryRequest(method, urlStr string, body io.ReadSeeker, h http.
 			return
 		}
 		logger.debugPrintln(err)
+
+		// retry internal server errors after a short delay
+		if resp.StatusCode == 500 {
+			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
+			continue
+		}
+
 		if body != nil {
 			if _, err = body.Seek(0, 0); err != nil {
 				return

--- a/putter.go
+++ b/putter.go
@@ -387,7 +387,7 @@ func (p *putter) retryRequest(method, urlStr string, body io.ReadSeeker, h http.
 		logger.debugPrintln(err)
 
 		// retry internal server errors after a short delay
-		if resp.StatusCode == 500 {
+		if resp != nil && resp.StatusCode == 500 {
 			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
 			continue
 		}


### PR DESCRIPTION
Handle 500 InternalErrors in the retryRequest functions.
