### PR TITLE
S3 keys containing = do not work.

### DIFF
--- a/sign.go
+++ b/sign.go
@@ -119,7 +119,7 @@ func (s *signer) buildCanonicalString() {
 	if uri != "" {
 		uri = "/" + strings.Join(strings.Split(uri, "/")[3:], "/")
 	} else {
-		uri = s.Request.URL.EscapedPath()
+		uri = strings.Replace(s.Request.URL.EscapedPath(), "=", "%3D", -1)
 	}
 	if uri == "" {
 		uri = "/"


### PR DESCRIPTION
When storing files backing Hive partitioned tables on S3, it is common for the keys to contain the "=" character.

Unfortunately, when passing S3Bucket.GetReader a key with the "=" character in it, the following error is always returned:  403: "The request signature we calculated does not match the signature you provided. Check your key and signing method."
