### PR TITLE
update regionMatcher regexp for china endpoint

### DIFF
--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -18,7 +18,7 @@ import (
 
 const versionParam = "versionId"
 
-var regionMatcher = regexp.MustCompile("s3-([a-z0-9-]+).amazonaws.com")
+var regionMatcher = regexp.MustCompile("s3[-.]([a-z0-9-]+).amazonaws.com([.a-z0-9]*)")
 
 // S3 contains the domain or endpoint of an S3-compatible service and
 // the authentication keys for that service.


### PR DESCRIPTION
The regexp will match on s3.cn-north-1.amazonaws.com.cn as well as
endpoints prefixed s3. instead of s3-, which are both valid such as
s3.eu-central-1.amazonaws.com