### PR TITLE
Add support for S3 accelerate

### DIFF
--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -29,16 +29,22 @@ type S3 struct {
 
 // Region returns the service region infering it from S3 domain.
 func (s *S3) Region() string {
+	region := os.Getenv("AWS_REGION")
 	switch s.Domain {
 	case "s3.amazonaws.com", "s3-external-1.amazonaws.com":
 		return "us-east-1"
+	case "s3-accelerate.amazonaws.com":
+		if region == "" {
+			panic("can't find endpoint region")
+		}
+		return region
 	default:
 		regions := regionMatcher.FindStringSubmatch(s.Domain)
 		if len(regions) < 2 {
-			if region := os.Getenv("AWS_REGION"); region != "" {
-				return region
+			if region == "" {
+				panic("can't find endpoint region")
 			}
-			panic("can't find endpoint region")
+			return region
 		}
 		return regions[1]
 	}


### PR DESCRIPTION
Allow to support [Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html), this will fallback to ``AWS_REGION`` when provided with the s3 accelerate domain.