### PR TITLE
Use AWS_REGION environment variable if it is set

### DIFF
--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -30,6 +30,9 @@ type S3 struct {
 // Region returns the service region infering it from S3 domain.
 func (s *S3) Region() string {
 	region := os.Getenv("AWS_REGION")
+	if region != "" {
+		return region
+	}
 	switch s.Domain {
 	case "s3.amazonaws.com", "s3-external-1.amazonaws.com":
 		return "us-east-1"


### PR DESCRIPTION
Use AWS_REGION environment variable if it is set.

Without this change, trying to put to a bucket in a region other than
us-east-1 results in something like:

> gof3r error: 400: "The authorization header is malformed; the region
> 'us-east-1' is wrong; expecting 'us-west-2'"

I only have buckets in us-west-2, and I have verified that this
change (and export AWS_REGION=us-west-2) allows me to `put`, `cp`, and
`get` objects from those buckets.

I am not sure how it interacts with some of the other features.

This may solve #90 
