### PR TITLE
Allow ampersands and colons in key names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.mprof
 *.out
 .env
+.idea
+out
+*.iml
+gof3r/gof3r
+

--- a/sign.go
+++ b/sign.go
@@ -125,6 +125,9 @@ func (s *signer) buildCanonicalString() {
 		uri = "/"
 	}
 
+	uri = strings.Replace(uri, "@", "%40", -1)
+	uri = strings.Replace(uri, ":", "%3A", -1)
+
 	s.canonicalString = strings.Join([]string{
 		s.Request.Method,
 		uri,


### PR DESCRIPTION
Fix for https://github.com/rlmcpherson/s3gof3r/issues/112 and https://github.com/rlmcpherson/s3gof3r/issues/110

The tool does not fail now if the bucket key has `@` or `:` in it