### PR TITLE
check Md5Check flag when deleting

### DIFF
--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -195,8 +195,10 @@ func (b *Bucket) Delete(path string) error {
 		return err
 	}
 	// try to delete md5 file
-	if err := b.delete(fmt.Sprintf("/.md5/%s.md5", path)); err != nil {
-		return err
+	if b.Md5Check {
+		if err := b.delete(fmt.Sprintf("/.md5/%s.md5", path)); err != nil {
+			return err
+		}
 	}
 
 	logger.Printf("%s deleted from %s\n", path, b.Name)


### PR DESCRIPTION
This prevents a panic in the client when the .md5 file doesn't exist due to the Md5Check being false