### PR TITLE
Fix MD5 hash comparison

### DIFF
--- a/putter.go
+++ b/putter.go
@@ -276,11 +276,11 @@ func (p *putter) Close() (err error) {
 		return
 	}
 	// strip part count from end and '"' from front.
-	remoteMd5ofParts := strings.Split(p.ETag, "-")[0]
+	remoteMd5ofParts := strings.Trim(p.ETag, "\"")
+	remoteMd5ofParts = strings.Split(remoteMd5ofParts, "-")[0]
 	if len(remoteMd5ofParts) == 0 {
 		return fmt.Errorf("Nil ETag")
 	}
-	remoteMd5ofParts = remoteMd5ofParts[1:len(remoteMd5ofParts)]
 	if calculatedMd5ofParts != remoteMd5ofParts {
 		if err != nil {
 			return err

--- a/putter.go
+++ b/putter.go
@@ -275,7 +275,7 @@ func (p *putter) Close() (err error) {
 	if err != nil {
 		return
 	}
-	// strip part count from end and '"' from front.
+	// Trim quotes '"' and strip part count from end.
 	remoteMd5ofParts := strings.Trim(p.ETag, "\"")
 	remoteMd5ofParts = strings.Split(remoteMd5ofParts, "-")[0]
 	if len(remoteMd5ofParts) == 0 {


### PR DESCRIPTION
When uploading a file with `gof3r`  to our S3 compatible storage *(gof3r v0.4.10 to use Signature Version 2 with Ceph, our setup doesn't support v4)*, the upload is successful but gof3r exits with the following error:
```
gof3r error: MD5 hash of part hashes comparison failed. Hash from multipart complete header: 
baac207116c3c53ca4e2e2e7cc321c3. Calculated multipart hash: 5baac207116c3c53ca4e2e2e7cc321c3.
```

As you can see, the remote hash is missing the first character. Checking the code, the first character was always stripped, assuming it is always a quote (`"`) however, this is not the case. Basically replaced the substring by simply trimming the quotes.