### PR TITLE
Add support for retrieving credentials from ECS container agent.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -15,6 +15,7 @@ type Keys struct {
 	AccessKey     string
 	SecretKey     string
 	SecurityToken string
+	Expiration    string
 }
 
 type mdCreds struct {
@@ -89,6 +90,7 @@ func getKeysFromUri(credentialPath string) (keys Keys, err error) {
 		AccessKey:     creds.AccessKeyID,
 		SecretKey:     creds.SecretAccessKey,
 		SecurityToken: creds.Token,
+		Expiration:    creds.Expiration,
 	}
 
 	return

--- a/auth.go
+++ b/auth.go
@@ -32,6 +32,21 @@ type mdCreds struct {
 func InstanceKeys() (keys Keys, err error) {
 
 	rolePath := "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+	return getKeysFromUri(rolePath)
+}
+
+// ECSTaskKeys Requests the AWS keys from the ECS container agent
+// Assumes only one IAM role.
+func ECSTaskKeys() (keys Keys, err error) {
+	taskCredentialsUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	if taskCredentialsUri == "" {
+		err = fmt.Errorf("task credentials uri not set in environment: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+		return
+	}
+	return getKeysFromUri(fmt.Sprintf("http://169.254.170.2%s", taskCredentialsUri))
+}
+
+func getKeysFromUri(rolePath string) (keys Keys, err error) {
 	var creds mdCreds
 
 	// request the role name for the instance

--- a/auth.go
+++ b/auth.go
@@ -32,22 +32,6 @@ type mdCreds struct {
 func InstanceKeys() (keys Keys, err error) {
 
 	rolePath := "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
-	return getKeysFromUri(rolePath)
-}
-
-// ECSTaskKeys Requests the AWS keys from the ECS container agent
-// Assumes only one IAM role.
-func ECSTaskKeys() (keys Keys, err error) {
-	taskCredentialsUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
-	if taskCredentialsUri == "" {
-		err = fmt.Errorf("task credentials uri not set in environment: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
-		return
-	}
-	return getKeysFromUri(fmt.Sprintf("http://169.254.170.2%s", taskCredentialsUri))
-}
-
-func getKeysFromUri(rolePath string) (keys Keys, err error) {
-	var creds mdCreds
 
 	// request the role name for the instance
 	// assumes there is only one
@@ -66,8 +50,25 @@ func getKeysFromUri(rolePath string) (keys Keys, err error) {
 		return
 	}
 
+	return getKeysFromUri(rolePath + string(role))
+}
+
+// ECSTaskKeys Requests the AWS keys from the ECS container agent
+// Assumes only one IAM role.
+func ECSTaskKeys() (keys Keys, err error) {
+	taskCredentialsUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	if taskCredentialsUri == "" {
+		err = fmt.Errorf("task credentials uri not set in environment: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+		return
+	}
+	return getKeysFromUri(fmt.Sprintf("http://169.254.170.2%s", taskCredentialsUri))
+}
+
+func getKeysFromUri(credentialPath string) (keys Keys, err error) {
+	var creds mdCreds
+
 	// request the credential metadata for the role
-	resp, err = http.Get(rolePath + string(role))
+	resp, err := http.Get(credentialPath)
 	if err != nil {
 		return
 	}

--- a/sign.go
+++ b/sign.go
@@ -127,6 +127,7 @@ func (s *signer) buildCanonicalString() {
 
 	uri = strings.Replace(uri, "@", "%40", -1)
 	uri = strings.Replace(uri, ":", "%3A", -1)
+	uri = strings.Replace(uri, "=", "%3D", -1)
 
 	s.canonicalString = strings.Join([]string{
 		s.Request.Method,


### PR DESCRIPTION
This change adds another ...Keys() method that allows credentials to be retrieved from the ECS container agent.  More information on how this works is available here:

http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

We're currently using s3gof3r on our product and hope this addition is useful to others as well!