### PR TITLE
Output the ETag if it fails

### DIFF
--- a/putter.go
+++ b/putter.go
@@ -220,7 +220,7 @@ func (p *putter) putPart(part *part) error {
 	}
 	s = s[1 : len(s)-1] // includes quote chars for some reason
 	if part.ETag != s {
-		return fmt.Errorf("Response etag does not match. Remote:%s Calculated:%s", s, p.ETag)
+		return fmt.Errorf("Response etag does not match. Remote:%s Calculated:%s", s, part.ETag)
 	}
 	return nil
 }


### PR DESCRIPTION
`p.ETag` is undefined/empty, this fix means that it correctly outputs a failing etag as you'd expect it to