### PR TITLE
Support ECS metadata role path

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"time"
 )
 
@@ -84,7 +83,7 @@ func getMetaDataKeys(rolePath string) (keys Keys, err error) {
 func ECSKeys() (keys Keys, err error) {
 	roleRelativeUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 
-	return getMetaDataKeys(path.Join("169.254.170.2", roleRelativeUri))
+	return getMetaDataKeys(fmt.Sprint("http://169.254.170.2/", roleRelativeUri))
 }
 
 // InstanceKeys Requests the AWS keys from the instance-based metadata on EC2

--- a/auth.go
+++ b/auth.go
@@ -84,7 +84,7 @@ func getMetaDataKeys(rolePath string) (keys Keys, err error) {
 func ECSKeys() (keys Keys, err error) {
 	roleRelativeUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 
-	return getMetaDataKeys(path.Join("http://169.254.170.2", roleRelativeUri))
+	return getMetaDataKeys(path.Join("169.254.170.2", roleRelativeUri))
 }
 
 // InstanceKeys Requests the AWS keys from the instance-based metadata on EC2

--- a/auth.go
+++ b/auth.go
@@ -84,7 +84,7 @@ func getMetaDataKeys(rolePath string) (keys Keys, err error) {
 func ECSKeys() (keys Keys, err error) {
 	roleRelativeUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 
-	return getMetaDataKeys(path.Join("169.254.170.2", roleRelativeUri))
+	return getMetaDataKeys(path.Join("http://169.254.170.2", roleRelativeUri))
 }
 
 // InstanceKeys Requests the AWS keys from the instance-based metadata on EC2

--- a/auth.go
+++ b/auth.go
@@ -83,7 +83,7 @@ func getMetaDataKeys(rolePath string) (keys Keys, err error) {
 func ECSKeys() (keys Keys, err error) {
 	roleRelativeUri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 
-	return getMetaDataKeys(fmt.Sprint("http://169.254.170.2/", roleRelativeUri))
+	return getMetaDataKeys(fmt.Sprint("http://169.254.170.2", roleRelativeUri))
 }
 
 // InstanceKeys Requests the AWS keys from the instance-based metadata on EC2


### PR DESCRIPTION
In order to use IAM roles within ECS tasks, it is necessarily to use a different ip + relative path to access the meta data server within a running ECS task container:

```
curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
```

s3gof3r currently hardcodes the path to:
```
http://169.254.169.254/latest/meta-data/iam/security-credentials/
```

I am preposing refactoring to allow for ECS role paths and Instance role paths.

see: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html